### PR TITLE
feature: multi-line support

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -30,7 +30,7 @@ export default class App extends React.Component<{}, $FlowFixMeState> {
         <View style={styles.segmentSection}>
           <SegmentedControl
             values={[
-              'One',
+              'OneOne',
               'Two',
               require('../assets/images/user.png'),
               'Three',

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -30,7 +30,7 @@ export default class App extends React.Component<{}, $FlowFixMeState> {
         <View style={styles.segmentSection}>
           <SegmentedControl
             values={[
-              'OneOne',
+              'One\nOne',
               'Two',
               require('../assets/images/user.png'),
               'Three',

--- a/ios/RNCSegmentedControl.m
+++ b/ios/RNCSegmentedControl.m
@@ -25,8 +25,8 @@
 
 - (void)setValues:(NSArray *)values {
 	[self removeAllSegments];
+  [[UILabel appearanceWhenContainedInInstancesOfClasses:@[[UISegmentedControl class]]] setNumberOfLines:0];
 	for (id segment in values) {
-    [[UILabel appearanceWhenContainedInInstancesOfClasses:@[[UISegmentedControl class]]] setNumberOfLines:0];
 
 		if ([segment isKindOfClass:[NSMutableDictionary class]]){
 			UIImage *image = [[RCTConvert UIImage:segment] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];

--- a/ios/RNCSegmentedControl.m
+++ b/ios/RNCSegmentedControl.m
@@ -26,6 +26,8 @@
 - (void)setValues:(NSArray *)values {
 	[self removeAllSegments];
 	for (id segment in values) {
+    [[UILabel appearanceWhenContainedInInstancesOfClasses:@[[UISegmentedControl class]]] setNumberOfLines:0];
+
 		if ([segment isKindOfClass:[NSMutableDictionary class]]){
 			UIImage *image = [[RCTConvert UIImage:segment] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
 			[self insertSegmentWithImage:image


### PR DESCRIPTION
I needed multi-lines inside the segment control.
I don't know any Objective-C but managed to do the change, if someone can do it cleaner - I would be more than happy 😄 

(simple example with the text "One/nOne"
![Screenshot 2020-08-08 at 23 36 31](https://user-images.githubusercontent.com/23147325/89719388-650d0b00-d9d0-11ea-9f17-84a8732fb570.png)

https://github.com/react-native-community/segmented-control/issues/116