### PR TITLE
feat: Add Custom Font Weight Styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ An object container
 - `color`: color of segment text
 - `fontSize`: font-size of segment text
 - `fontFamily`: font-family of segment text
+- `fontWeight`: font-weight of segment text
 
 ### `activeFontStyle`
 
@@ -213,6 +214,7 @@ An object container
 - `color`: overrides color of selected segment text
 - `fontSize`: overrides font-size of selected segment text
 - `fontFamily`: overrides font-family of selected segment text
+- `fontWeight`: overrides font-weight of selected segment text
 
 ## Maintainers
 

--- a/js/SegmentedControlTab.js
+++ b/js/SegmentedControlTab.js
@@ -45,12 +45,13 @@ export const SegmentedControlTab = ({
 }: Props): React.Node => {
   const colorSchemeHook = useColorScheme();
   const colorScheme = appearance || colorSchemeHook;
-  const {color: textColor, fontSize, fontFamily} = fontStyle;
+  const {color: textColor, fontSize, fontFamily, fontWeight} = fontStyle;
 
   const {
     color: activeColor,
     fontSize: activeFontSize,
     fontFamily: activeFontFamily,
+    fontWeight: activeFontWeight,
   } = activeFontStyle;
 
   const getColor = () => {
@@ -69,12 +70,14 @@ export const SegmentedControlTab = ({
     fontFamily: activeFontFamily || fontFamily,
     fontSize: activeFontSize || fontSize,
     color: activeColor || color,
+    fontWeight: activeFontWeight || fontWeight || styles.activeText.fontWeight,
   };
 
   const idleStyle = {
     color,
     fontSize: fontSize,
     fontFamily: fontFamily,
+    fontWeight: fontWeight,
   };
 
   return (

--- a/js/types.js
+++ b/js/types.js
@@ -29,7 +29,18 @@ export type FontStyle = $ReadOnly<{|
   /**
    * Font Weight of the Segmented Control
    */
-  fontWeight?: string,
+  fontWeight?:
+    | 'normal'
+    | 'bold'
+    | '100'
+    | '200'
+    | '300'
+    | '400'
+    | '500'
+    | '600'
+    | '700'
+    | '800'
+    | '900',
 |}>;
 
 export type SegmentedControlProps = $ReadOnly<{|

--- a/js/types.js
+++ b/js/types.js
@@ -26,6 +26,10 @@ export type FontStyle = $ReadOnly<{|
    * Font Family of the Segmented Control
    */
   fontFamily?: string,
+  /**
+   * Font Weight of the Segmented Control
+   */
+  fontWeight?: string,
 |}>;
 
 export type SegmentedControlProps = $ReadOnly<{|


### PR DESCRIPTION
# Overview
Added custom font styling for font-weight to fix issue #130


# Test Plan
I Added fontWeight property on fontStyle & activeFontStyle props. Here is the example:

```javascript
<SegmentedControl
  values={['One', 'Two']}
  selectedIndex={this.state.selectedIndex}
  onChange={(event) => {
    this.setState({selectedIndex: event.nativeEvent.selectedSegmentIndex});
  }}
  activeFontStyle={{
    fontWeight: '500'
  }}
  fontStyle={{
    fontWeight: '200'
  }}
/>
```