### PR TITLE
Allow touchable to be stylable

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,41 @@ An object container
 - `fontFamily`: overrides font-family of selected segment text
 - `fontWeight`: overrides font-weight of selected segment text
 
+### `tabStyle`
+
+(Android and Web only) Styles the clickable surface which is responsible to change tabs
+| Type | Required | Platform |
+| ------ | -------- | -------- |
+| object | No | Android, Web |
+
+Extends [ViewStyles](https://reactnative.dev/docs/view-style-props)
+
+## Tips and Tricks
+
+### How can I increase the height of the tab ?
+
+For android and IOS, simply pass `prop.style`:
+
+```json
+{
+  "height": number
+}
+```
+
+For react-native-web, additionally pass :
+
+```json
+{
+  "paddingVertical": number,
+  or
+  "height": number
+}
+```
+
+### Adding padding makes text disappear on Android
+
+If padding amount exceeds the fixed height of the container, it will shrink the text. So either increase the height or reduce your padding. 
+
 ## Maintainers
 
 - [M.Haris Baig](https://github.com/harisbaig100)

--- a/index.d.ts
+++ b/index.d.ts
@@ -109,7 +109,7 @@ export interface SegmentedControlProps extends ViewProps {
   /**
    * Touchable style properties for Segmented Control Tab
    */
-  touchableStyle?: ViewStyle;
+  tabStyle?: ViewStyle;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ import {
   NativeMethods,
   Constructor,
   TargetedEvent,
+  ViewStyle,
 } from 'react-native';
 
 export interface NativeSegmentedControlIOSChangeEvent extends TargetedEvent {
@@ -104,6 +105,11 @@ export interface SegmentedControlProps extends ViewProps {
    * Active Font style properties of the Segmented Control
    */
   activeFontStyle?: FontStyle;
+
+  /**
+   * Touchable style properties for Segmented Control Tab
+   */
+  touchableStyle?: ViewStyle;
 }
 
 /**

--- a/js/SegmentedControl.ios.js
+++ b/js/SegmentedControl.ios.js
@@ -91,11 +91,7 @@ class SegmentedControlIOS extends React.Component<Props> {
         )}
         {...props}
         ref={forwardedRef}
-        style={[
-          styles.segmentedControl,
-          this.props.style,
-          this.props.touchableStyle,
-        ]}
+        style={[styles.segmentedControl, this.props.style]}
         onChange={this._onChange}
       />
     );

--- a/js/SegmentedControl.ios.js
+++ b/js/SegmentedControl.ios.js
@@ -91,7 +91,11 @@ class SegmentedControlIOS extends React.Component<Props> {
         )}
         {...props}
         ref={forwardedRef}
-        style={[styles.segmentedControl, this.props.style]}
+        style={[
+          styles.segmentedControl,
+          this.props.style,
+          this.props.touchableStyle,
+        ]}
         onChange={this._onChange}
       />
     );

--- a/js/SegmentedControl.js
+++ b/js/SegmentedControl.js
@@ -32,6 +32,7 @@ const SegmentedControl = ({
   values,
   tintColor,
   backgroundColor,
+  touchableStyle,
   fontStyle,
   activeFontStyle,
   appearance,
@@ -101,6 +102,7 @@ const SegmentedControl = ({
                 key={index}
                 value={value}
                 tintColor={tintColor}
+                touchableStyle={touchableStyle}
                 fontStyle={fontStyle}
                 activeFontStyle={activeFontStyle}
                 appearance={colorScheme}

--- a/js/SegmentedControl.js
+++ b/js/SegmentedControl.js
@@ -32,7 +32,7 @@ const SegmentedControl = ({
   values,
   tintColor,
   backgroundColor,
-  touchableStyle,
+  tabStyle,
   fontStyle,
   activeFontStyle,
   appearance,
@@ -102,7 +102,7 @@ const SegmentedControl = ({
                 key={index}
                 value={value}
                 tintColor={tintColor}
-                touchableStyle={touchableStyle}
+                tabStyle={tabStyle}
                 fontStyle={fontStyle}
                 activeFontStyle={activeFontStyle}
                 appearance={colorScheme}

--- a/js/SegmentedControlTab.js
+++ b/js/SegmentedControlTab.js
@@ -15,7 +15,7 @@ import {
   useColorScheme,
 } from 'react-native';
 
-import type {FontStyle} from './types';
+import type {FontStyle, ViewStyle} from './types';
 
 type Props = $ReadOnly<{|
   value: string | number | Object,
@@ -25,6 +25,7 @@ type Props = $ReadOnly<{|
   enabled: boolean,
   fontStyle?: FontStyle,
   activeFontStyle?: FontStyle,
+  touchableStyle?: ViewStyle,
   appearance?: 'dark' | 'light' | null,
 |}>;
 
@@ -42,6 +43,7 @@ export const SegmentedControlTab = ({
   fontStyle = {},
   activeFontStyle = {},
   appearance,
+  touchableStyle,
 }: Props): React.Node => {
   const colorSchemeHook = useColorScheme();
   const colorScheme = appearance || colorSchemeHook;
@@ -82,7 +84,7 @@ export const SegmentedControlTab = ({
 
   return (
     <TouchableOpacity
-      style={styles.container}
+      style={[styles.container, touchableStyle]}
       disabled={!enabled}
       onPress={onSelect}
       accessibilityState={{selected: selected, disabled: !enabled}}>

--- a/js/SegmentedControlTab.js
+++ b/js/SegmentedControlTab.js
@@ -88,7 +88,7 @@ export const SegmentedControlTab = ({
       disabled={!enabled}
       onPress={onSelect}
       accessibilityState={{selected: selected, disabled: !enabled}}>
-      <View style={[styles.default]}>
+      <View style={styles.default}>
         {typeof value === 'number' || typeof value === 'object' ? (
           <Image source={value} style={styles.segmentImage} />
         ) : isBase64(value) ? (

--- a/js/SegmentedControlTab.js
+++ b/js/SegmentedControlTab.js
@@ -25,7 +25,7 @@ type Props = $ReadOnly<{|
   enabled: boolean,
   fontStyle?: FontStyle,
   activeFontStyle?: FontStyle,
-  touchableStyle?: ViewStyle,
+  tabStyle?: ViewStyle,
   appearance?: 'dark' | 'light' | null,
 |}>;
 
@@ -43,7 +43,7 @@ export const SegmentedControlTab = ({
   fontStyle = {},
   activeFontStyle = {},
   appearance,
-  touchableStyle,
+  tabStyle,
 }: Props): React.Node => {
   const colorSchemeHook = useColorScheme();
   const colorScheme = appearance || colorSchemeHook;
@@ -84,7 +84,7 @@ export const SegmentedControlTab = ({
 
   return (
     <TouchableOpacity
-      style={[styles.container, touchableStyle]}
+      style={[styles.container, tabStyle]}
       disabled={!enabled}
       onPress={onSelect}
       accessibilityState={{selected: selected, disabled: !enabled}}>

--- a/js/types.js
+++ b/js/types.js
@@ -5,6 +5,7 @@
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 export type Event = SyntheticEvent<
   $ReadOnly<{|
@@ -12,6 +13,8 @@ export type Event = SyntheticEvent<
     selectedSegmentIndex: number,
   |}>,
 >;
+
+export type ViewStyle = ViewStyleProp;
 
 export type FontStyle = $ReadOnly<{|
   /**
@@ -99,4 +102,9 @@ export type SegmentedControlProps = $ReadOnly<{|
    * it will override fontStyle for the selected segment
    */
   activeFontStyle?: FontStyle,
+
+  /**
+   * Touchable style properties for Segmented Control Tab
+   */
+  touchableStyle?: ViewStyle,
 |}>;

--- a/js/types.js
+++ b/js/types.js
@@ -106,5 +106,5 @@ export type SegmentedControlProps = $ReadOnly<{|
   /**
    * Touchable style properties for Segmented Control Tab
    */
-  touchableStyle?: ViewStyle,
+  tabStyle?: ViewStyle,
 |}>;


### PR DESCRIPTION
# Overview

Based on issue: https://github.com/react-native-segmented-control/segmented-control/issues/216

There is a problem on how react-native-web handles the transformation when it comes to flex, absolute and relative positioning. Basically Text container (TouchableOpacity in our case) is not expanding to full size.

Thus  I opened API for TouchableOpacity styles. This will allow users to change actual padding of the clickable area. No backwards compat introduced, very small code change but this will grant devs more power when it comes to styling.

Since library uses different components for IOS and android:

- in ios we can prepend styles to RNCSegmentedControlNativeComponent,
- in android we can add it to the TouchableOpacity

# Test Plan

I dont see any tests in the library so here is my video:

https://user-images.githubusercontent.com/7356299/121308930-e50e4500-c901-11eb-8180-c7a0f0ca660d.mov

If you would like to test it yourself, just point your dependency to my branch:

```
"@react-native-segmented-control/segmented-control": "https://github.com/mmehmetAliIzci/segmented-control.git#feat/touchable-styles",
```
