### PR TITLE
chore: fix node version used in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node-version: [10]
+        node-version: [12]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node-version: [10]
+        node-version: [12]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node-version: [10]
+        node-version: [12]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node-version: [10]
+        node-version: [12]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -87,10 +87,10 @@ jobs:
       - name: Build Android Example App and Library
         run: cd example/android && ./gradlew clean assembleDebug
   ios:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [10]
+        node-version: [12]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
use node v12 for ci as 10 is eol

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
