### PR TITLE
[README] Update note about Expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For Android and Web, it has a js implementation that mocks iOS 13 style of UISeg
 | v2.2.0                         | >= 0.62      |
 | <= v2.2.0                      | >= 0.57      |
 
-This module is NOT supported for expo.
+This module is NOT supported in the Expo Go app on iOS, because it requires custom native code. You need to use a custom development client or eject into bare workflow in order to use this module on iOS.
 
 ## Getting started
 


### PR DESCRIPTION
# Overview

Expo now supports custom native code. The only part that doesn't is the Expo Go app (and old classic `expo build`), but for this purpose a [custom development client](https://docs.expo.dev/clients/introduction/) can be built. 

[More info in Expo docs](https://docs.expo.dev/workflow/customizing/).

_P.S. 💡 Idea for improvement: fall back to JS-only module, when the iOS native component cannot be found._

# Test Plan

Previewed markdown.
