### PR TITLE
Adjust segmentWidth when values prop changes on android

### DIFF
--- a/js/SegmentedControl.js
+++ b/js/SegmentedControl.js
@@ -41,6 +41,7 @@ const SegmentedControl = ({
   const colorScheme = appearance || colorSchemeHook;
   const [segmentWidth, setSegmentWidth] = React.useState(0);
   const animation = React.useRef(new Animated.Value(0)).current;
+  const [containerWidth, setContainerWidth] = React.useState(0);
 
   const handleChange = (index: number) => {
     // mocks iOS's nativeEvent
@@ -66,6 +67,14 @@ const SegmentedControl = ({
     }
   }, [animation, segmentWidth, selectedIndex]);
 
+  React.useEffect(() => {
+    const newSegmentWidth = values.length ? containerWidth / values.length : 0;
+    if (newSegmentWidth !== segmentWidth) {
+      animation.setValue(newSegmentWidth * (selectedIndex || 0));
+      setSegmentWidth(newSegmentWidth);
+    }
+  }, [values.length, containerWidth]);
+
   return (
     <View
       style={[
@@ -80,11 +89,7 @@ const SegmentedControl = ({
           layout: {width},
         },
       }) => {
-        const newSegmentWidth = values.length ? width / values.length : 0;
-        if (newSegmentWidth !== segmentWidth) {
-          animation.setValue(newSegmentWidth * (selectedIndex || 0));
-          setSegmentWidth(newSegmentWidth);
-        }
+        setContainerWidth(width);
       }}>
       {!backgroundColor && !tintColor && (
         <SegmentsSeparators


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

On android, the `SegmentedControl` component does not react properly to changes in the `values` prop, thus occasionally resulting in situations like this: 

<img width="332" alt="Screen Shot 2022-03-01 at 2 30 02 PM" src="https://user-images.githubusercontent.com/12438838/156260431-894b8772-166d-4122-a7ed-677ddaa2c7f7.png">

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Changes can be verified by adding a simple `setTimeout` that changes the length of the `values` array passed to the component after it has been mounted.
