### PR TITLE
fix(types): utility type removed from RN 0.71

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,10 +6,11 @@ import {
   ViewProps,
   NativeSyntheticEvent,
   NativeMethods,
-  Constructor,
   TargetedEvent,
   ViewStyle,
 } from 'react-native';
+
+type Constructor<T> = new (...args: any[]) => T;
 
 export interface NativeSegmentedControlIOSChangeEvent extends TargetedEvent {
   value: string;


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Updating to react native 0.71, TypeScript errors on this library. The utility type `Constructor` is private in latest typings. Using this export degrades to `any` type.

`JSX element class does not support attributes because it does not have a 'props' property.`


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

`npx tsc` runs clean after making this change on a RN 0.71 app.