### PR TITLE
Add utility type removed in RN 0.71

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,10 +6,11 @@ import {
   ViewProps,
   NativeSyntheticEvent,
   NativeMethods,
-  Constructor,
   TargetedEvent,
   ViewStyle,
 } from 'react-native';
+
+type Constructor<T> = new (...args: any[]) => T;
 
 export interface NativeSegmentedControlIOSChangeEvent extends TargetedEvent {
   value: string;


### PR DESCRIPTION
# Overview
After updating to RN 0.71, this library throws a `JSX element class does not support attributes because it does not have a 'props' property` error (see [repro](https://github.com/philiplindberg/segmented-control-repro)). The utility type `Constructor` is private in latest RN typings, so defining this type in `index.d.ts` resolves the issue.

# Repro
- Clone [repro](https://github.com/philiplindberg/segmented-control-repro)
- Run `yarn`
- Run `yarn tsc`
- Notice `JSX element class does not support attributes...` in console
