### PR TITLE
fix: content not visible on js version

### DIFF
--- a/js/SegmentedControl.js
+++ b/js/SegmentedControl.js
@@ -92,6 +92,19 @@ const SegmentedControl = ({
           selectedIndex={selectedIndex}
         />
       )}
+      {selectedIndex != null && segmentWidth ? (
+        <Animated.View
+          style={[
+            styles.slider,
+            {
+              transform: [{translateX: animation}],
+              width: segmentWidth - 4,
+              backgroundColor:
+                tintColor || (colorScheme === 'dark' ? '#636366' : 'white'),
+            },
+          ]}
+        />
+      ) : null}
       <View style={styles.segmentsContainer}>
         {values &&
           values.map((value, index) => {
@@ -113,19 +126,6 @@ const SegmentedControl = ({
             );
           })}
       </View>
-      {selectedIndex != null && segmentWidth ? (
-        <Animated.View
-          style={[
-            styles.slider,
-            {
-              transform: [{translateX: animation}],
-              width: segmentWidth - 4,
-              backgroundColor:
-                tintColor || (colorScheme === 'dark' ? '#636366' : 'white'),
-            },
-          ]}
-        />
-      ) : null}
     </View>
   );
 };


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->

This fixes the appearance of the JS version of the segmented control


<details>
  <summary>screenshots</summary>
  

before

![Screenshot_1687268903](https://github.com/react-native-segmented-control/segmented-control/assets/1566403/12d95a50-e038-488b-80f3-259ff502c9e2)

after

![Screenshot_1687269144](https://github.com/react-native-segmented-control/segmented-control/assets/1566403/adce0557-7ff6-44f5-a722-bbb1d67aa93d)

</details>



# Test Plan

I'm not able to test because I'm not able to start up the example app in this repo, but tested this elsewhere