### PR TITLE
fix:Fix text color reverting to default after changing tintColor

### DIFF
--- a/ios/RNCSegmentedControl.m
+++ b/ios/RNCSegmentedControl.m
@@ -60,15 +60,6 @@
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     [self setSelectedSegmentTintColor:tintColor];
-    NSDictionary *attributes = [NSDictionary
-        dictionaryWithObjectsAndKeys:tintColor, NSForegroundColorAttributeName,
-                                     nil];
-    NSDictionary *activeAttributes = [NSDictionary
-        dictionaryWithObjectsAndKeys:UIColor.labelColor,
-                                     NSForegroundColorAttributeName, nil];
-    [self setTitleTextAttributes:attributes forState:UIControlStateNormal];
-    [self setTitleTextAttributes:activeAttributes
-                        forState:UIControlStateSelected];
   }
 #endif
 }


### PR DESCRIPTION
# Overview
I noticed a bug where the text color of the component would revert back to its default value after changing the tintColor. This behavior is not ideal as it disrupts the user experience and makes the component less flexible for dynamic UI changes. My motivation for making this change is to fix this issue and improve the component's reliability.

related with https://github.com/react-native-segmented-control/segmented-control/issues/641

# Test Plan
Manually tested the component on multiple devices running iOS 13 and above.
Changed the tintColor dynamically after the component had rendered to verify that the text color does not revert to its default value.
Checked other properties to ensure they are not affected by this change.
