### PR TITLE
feat: Add visionOS support to podspec

### DIFF
--- a/react-native-segmented-control.podspec
+++ b/react-native-segmented-control.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "9.0"
+  s.platforms    = { :ios => "9.0", :visionos => "1.0" }
 
   s.source       = { :git => "https://github.com/react-native-segmented-control/segmented-control.git", :tag => "#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Add visionOS to support to the podspec. No big repo update to 0.73 this time. Maybe as a followup. 

# Test Plan

CI should pass
