### PR TITLE
Added testIDS prop which can be used to pass testID to individual segment buttons

### DIFF
--- a/ios/RNCSegmentedControl.h
+++ b/ios/RNCSegmentedControl.h
@@ -11,5 +11,6 @@
 @interface RNCSegmentedControl : UISegmentedControl
 @property(nonatomic, assign) NSInteger selectedIndex;
 @property(nonatomic, copy) RCTBubblingEventBlock onChange;
+@property(nonatomic, copy) NSArray *testIDS;
 
 @end

--- a/ios/RNCSegmentedControl.m
+++ b/ios/RNCSegmentedControl.m
@@ -88,4 +88,17 @@
 #endif
 }
 
+- (NSArray *)accessibilityElements {
+  NSArray *elements = [super accessibilityElements];
+  [elements enumerateObjectsUsingBlock:^(UIView *obj, NSUInteger idx, BOOL *stop) {
+    @try {
+      obj.accessibilityIdentifier = self.testIDS[idx];      
+    } @catch (NSException *exception) {
+      NSLog(@"%@", exception);
+    }
+  }];
+
+  return elements;
+}
+
 @end

--- a/ios/RNCSegmentedControlManager.m
+++ b/ios/RNCSegmentedControlManager.m
@@ -27,6 +27,7 @@ RCT_EXPORT_VIEW_PROPERTY(momentary, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(appearance, NSString)
+RCT_EXPORT_VIEW_PROPERTY(testIDS, NSArray)
 
 RCT_CUSTOM_VIEW_PROPERTY(fontStyle, NSObject, RNCSegmentedControl) {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) &&      \

--- a/js/SegmentedControl.js
+++ b/js/SegmentedControl.js
@@ -37,6 +37,7 @@ const SegmentedControl = ({
   activeFontStyle,
   appearance,
   accessibilityHintSeperator = 'out of',
+  testIDS,
 }: SegmentedControlProps): React.Node => {
   const colorSchemeHook = useColorScheme();
   const colorScheme = appearance || colorSchemeHook;
@@ -113,6 +114,7 @@ const SegmentedControl = ({
             return (
               <SegmentedControlTab
                 enabled={enabled}
+                testID={(testIDS?.length ?? 0) > index ? testIDS[index] : `${index}`}
                 selected={selectedIndex === index}
                 accessibilityHint={`${
                   index + 1

--- a/js/SegmentedControlTab.js
+++ b/js/SegmentedControlTab.js
@@ -94,8 +94,9 @@ export const SegmentedControlTab = ({
       onPress={onSelect}
       accessibilityHint={accessibilityHint}
       accessibilityRole="button"
-      accessibilityState={{selected: selected, disabled: !enabled}}>
-      <View testID={testID} style={styles.default}>
+      accessibilityState={{selected: selected, disabled: !enabled}}
+      testID={testID}>
+      <View style={styles.default}>
         {typeof value === 'number' || typeof value === 'object' ? (
           <Image source={value} style={styles.segmentImage} />
         ) : isBase64(value) ? (

--- a/js/types.js
+++ b/js/types.js
@@ -107,4 +107,10 @@ export type SegmentedControlProps = $ReadOnly<{|
    * Touchable style properties for Segmented Control Tab
    */
   tabStyle?: ViewStyle,
+
+
+  /**
+   * array testID to each segment button
+   */
+  testIDS: $ReadOnlyArray<string | number | Object>,
 |}>;


### PR DESCRIPTION
# Overview
Thanks for creating this owesome library. There is a small concern, even though it is very helpful. There is no feature for sending testIDs for individual segment buttons/components. I've done with the implementation of this feature for both Android and iOS and creating this PR. I hope this could get merged quickly, as we are in need of this change.

# Test Plan
Send an array of identifiers into testIDS and check if they are reflecting or not. 
ex:
<SegmentController 
{...props}
testIDS={["option1", "option2", "option3"]}
/>